### PR TITLE
Don't specify character encoding twice

### DIFF
--- a/home.html
+++ b/home.html
@@ -1,13 +1,12 @@
-<!DOCTYPE html> 
+<!DOCTYPE html>
 <!--    Copyright 2014 gokoururi
         This work is free. You can redistribute it and/or modify it under the
         terms of the Do What The Fuck You Want To Public License, Version 2,
         as published by Sam Hocevar. See the COPYING file for more details. -->
 <html>
     <head>
-        <title>Welcome Home</title>
-        <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
         <meta charset="utf-8">
+        <title>Welcome Home</title>
         <link rel="icon" href="images/ruri.ico" sizes="16x16 32x32 48x48 64x64" type="image/vnd.microsoft.icon" />
         <link rel="stylesheet" style="text/css" href="css/general.css" />
         <link rel="stylesheet" style="text/css" href="css/dark.css" title="Kuroneko" />


### PR DESCRIPTION
``` html
<meta charset="utf-8">
```

is all that is needed to specify character encoding in HTML5.

This patch also moves the charset above the `<title>` tag in order to avoid [potential XSS vectors](https://code.google.com/p/doctype-mirror/wiki/ArticleUtf7).
